### PR TITLE
add className to Link props

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ filtering. If you need a property that isn't supported. Feel free to PR.
     import Link from 'react-router-redux-dom-link'
 
     export default const AboutLinkComponent () => (
-        <Link to="/about" className='navLink'>About</Link>
+        <Link to="/about" className="navLink">About</Link>
     )
     ```  
     

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ filtering. If you need a property that isn't supported. Feel free to PR.
     import Link from 'react-router-redux-dom-link'
 
     export default const AboutLinkComponent () => (
-        <Link to="/about" replace className='navLink'>This link replaces the current URL</Link>
+        <Link to="/about" className='navLink'>About</Link>
     )
     ```  
     

--- a/README.md
+++ b/README.md
@@ -100,6 +100,18 @@ filtering. If you need a property that isn't supported. Feel free to PR.
                     history. If handled by the browser this path will be handled
                     like if you had provided it to the `href` attribute.
 
+* **className**  
+    *Type:*         `string`  
+    *Description:*  A css className to assign to the link.  This allows styling of the link
+    *Example*:
+    ```JSX
+    import Link from 'react-router-redux-dom-link'
+
+    export default const AboutLinkComponent () => (
+        <Link to="/about" replace className='navLink'>This link replaces the current URL</Link>
+    )
+    ```  
+    
 ## Contribute
 
 PRs welcome.

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -15,11 +15,11 @@ interface LinkDispatchProps {
 }
 
 export interface LinkOwnProps {
+  className?: string;
   onClick?: (e?: React.MouseEvent<HTMLAnchorElement>) => void;
   replace?: boolean;
   target?: string;
   to: string;
-  className: string;
 }
 
 type LinkProps = LinkDispatchProps & LinkOwnProps;
@@ -59,9 +59,9 @@ class Link extends React.Component<LinkProps, undefined> {
 
   public render(): JSX.Element {
     return (
-      <a href={this.props.to}
+      <a className={this.props.className}>
+         href={this.props.to}
          onClick={this.handleClick}
-         className={this.props.className}>
         {this.props.children}
       </a>
     );

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -19,6 +19,7 @@ export interface LinkOwnProps {
   replace?: boolean;
   target?: string;
   to: string;
+  className: string;
 }
 
 type LinkProps = LinkDispatchProps & LinkOwnProps;
@@ -57,7 +58,13 @@ class Link extends React.Component<LinkProps, undefined> {
   }
 
   public render(): JSX.Element {
-    return <a href={this.props.to} onClick={this.handleClick}>{this.props.children}</a>;
+    return (
+      <a href={this.props.to}
+         onClick={this.handleClick}
+         className={this.props.className}>
+        {this.props.children}
+      </a>
+    );
   }
 }
 

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -59,9 +59,11 @@ class Link extends React.Component<LinkProps, undefined> {
 
   public render(): JSX.Element {
     return (
-      <a className={this.props.className}>
-         href={this.props.to}
-         onClick={this.handleClick}
+      <a
+        className={this.props.className}
+        href={this.props.to}
+        onClick={this.handleClick}
+      >
         {this.props.children}
       </a>
     );


### PR DESCRIPTION
These commit adds ability to pass through `className` to the `a` tag and would be used like...

```JSX
    import Link from 'react-router-redux-dom-link'

    export default const AboutLinkComponent () => (
        <Link to="/about" className='navLink'>About</Link>
    )
```  
