### PR TITLE
Make functionality similar to original react-router Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,42 +39,8 @@ export default const AboutLinkComponent () => (
 ```
 
 ## API
+**Note**: You could use all `HTMLAnchorElement` properties along with specific `Link` properties as well.
 
-Note that divergant from the API of `react-router-dom`'s `Link` component this
-Library doesn't spread your props down to the `HTMLAnchorElement` without
-filtering. If you need a property that isn't supported. Feel free to PR.
-
-#### Properties:
-* **onClick**  
-    *Type*:         `(e?: React.MouseEvent<HTMLAnchorElement>) => void`  
-    *Description*:  Callback that gets called when the Element is clicked. If
-                    you call `e.preventDefault` the push/replace action won't
-                    be triggert.  
-    *Example*:  
-    ```JSX
-    import Link from 'react-router-redux-dom-link'
-
-    export default class AboutLinkComponent extends React.Component {
-        constructor() {
-            super();
-            this.handleClick = this.handleClick.bind(this);
-        }
-
-        handleClick(e) {
-            if(this.props.unsafedContent) {
-                e.preventDefault();
-                alert('Please save your content first!');
-            }
-        }
-
-        render() {
-            return (
-                <Link to="/about" onClick={this.handleClick}>
-                    Your a-tag content
-                </Link>);
-        }
-    }
-    ```  
 * **replace**  
     *Type*:         `boolean`  
     *Default:*      `false`  
@@ -88,11 +54,6 @@ filtering. If you need a property that isn't supported. Feel free to PR.
         <Link to="/about" replace>This link replaces the current URL</Link>
     )
     ```  
-* **target**  
-    *Type*:         `string`  
-    *Description*:  Just your [standard](https://html.spec.whatwg.org/multipage/semantics.html#attr-hyperlink-target)
-                    HTMLAnchorElement `target` attribute.
-
 * **to**  
     *Type:*         `string`  
     *Description:*  The destination path of the Link. If handled by component the
@@ -100,18 +61,40 @@ filtering. If you need a property that isn't supported. Feel free to PR.
                     history. If handled by the browser this path will be handled
                     like if you had provided it to the `href` attribute.
 
-* **className**  
-    *Type:*         `string`  
-    *Description:*  A css className to assign to the link.  This allows styling of the link
     *Example*:
     ```JSX
     import Link from 'react-router-redux-dom-link'
 
     export default const AboutLinkComponent () => (
-        <Link to="/about" className="navLink">About</Link>
+        <Link to="/about">Simple link</Link>
     )
     ```  
+* **to**
+    *Type:*         `{ hash?: string, pathname?: string, search?: string, state?: any }`  
+    *Description*   Object that describes the destination path. It can have following properties:  
     
+    * **pathname**: A string representing the path to link to.  
+    * **search**: A string representation of query parameters.  
+    * **hash**: A hash to put in the URL, e.g. `#a-hash`.  
+    * **state**: State to persist to the `location`.  
+                    
+    *Example*:
+    ```JSX
+    import Link from 'react-router-redux-dom-link'
+
+    export default const UserLinkComponent () => (
+        <Link 
+            pathname: '/users',
+            search: '?sort=name',
+            hash: '#the-hash',
+            state: { fromDashboard: true }
+        >
+            User link
+        </Link>
+    )
+    ```
+    
+
 ## Contribute
 
 PRs welcome.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ export default const AboutLinkComponent () => (
     *Description*:  Whether to push or replace the url provided to `to` in the
                     browser history.  
     *Example*:
-    ```JSX
+    ```jsx
     import Link from 'react-router-redux-dom-link'
 
     export default const AboutLinkComponent () => (
         <Link to="/about" replace>This link replaces the current URL</Link>
     )
-    ```  
+    ```
+
 * **to**  
     *Type:*         `string`  
     *Description:*  The destination path of the Link. If handled by component the
@@ -62,16 +63,18 @@ export default const AboutLinkComponent () => (
                     like if you had provided it to the `href` attribute.
 
     *Example*:
-    ```JSX
+    ```jsx
     import Link from 'react-router-redux-dom-link'
 
     export default const AboutLinkComponent () => (
         <Link to="/about">Simple link</Link>
     )
     ```  
-* **to**
+
+    or
+
     *Type:*         `{ hash?: string, pathname?: string, search?: string, state?: any }`  
-    *Description*   Object that describes the destination path. It can have following properties:  
+    *Description:*   Object that describes the destination path. It can have following properties:  
     
     * **pathname**: A string representing the path to link to.  
     * **search**: A string representation of query parameters.  

--- a/README.md
+++ b/README.md
@@ -79,15 +79,17 @@ export default const AboutLinkComponent () => (
     * **state**: State to persist to the `location`.  
                     
     *Example*:
-    ```JSX
+    ```jsx
     import Link from 'react-router-redux-dom-link'
 
     export default const UserLinkComponent () => (
         <Link 
-            pathname: '/users',
-            search: '?sort=name',
-            hash: '#the-hash',
-            state: { fromDashboard: true }
+            to={{
+                pathname: '/users',
+                search: '?sort=name',
+                hash: '#the-hash',
+                state: { fromDashboard: true }
+            }}
         >
             User link
         </Link>

--- a/package.json
+++ b/package.json
@@ -14,15 +14,21 @@
     "compile": "tsc"
   },
   "devDependencies": {
+    "@types/invariant": "^2.2.29",
+    "@types/prop-types": "^15.5.2",
     "@types/react": "^15.0.23",
     "@types/react-redux": "^4.4.40",
     "@types/react-router-redux": "^5.0.0",
+    "invariant": "^2.2.2",
     "typescript": "^2.3.2"
   },
   "peerDependencies": {
-    "react": "^15.5.4",
+    "react": "^15.0.0-0 || ^16.0.0-0",
     "react-redux": "^5.0.4",
-    "react-router-redux": "^5.0.0-alpha.6",
-    "redux": "^3.6.0"
+    "react-router-redux": "^5.0.0-alpha.6"
+  },
+  "dependencies": {
+    "history": "^4.7.2",
+    "prop-types": "^15.6.0"
   }
 }

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -13,7 +13,7 @@ const isModifiedEvent = (event: React.MouseEvent<HTMLAnchorElement>) =>
 
 interface LinkDispatchProps {
   pushUrl: typeof pushActionCreator;
-  replaceUrl: typeof pushActionCreator;
+  replaceUrl: typeof replaceActionCreator;
 }
 
 export interface LinkOwnProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -1,4 +1,4 @@
-import {LocationDescriptor} from 'history';
+import { LocationDescriptor } from 'history';
 import * as invariant from 'invariant';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';


### PR DESCRIPTION
Current implementation is less functional than original `Link`. I improved the code in accordance with current `react-router` implementation. 
* Add ability to consume `History.LocationDescriptor`
* Add `PropTypes` for using in non-typescript projects
* Simplify action creators binding
* Add ability to use `HTMLAnchorElement` properties as well as Link props
* Allow using with React 16